### PR TITLE
Updated the boot network count check

### DIFF
--- a/tests/test_network_count_check.py
+++ b/tests/test_network_count_check.py
@@ -343,7 +343,7 @@ class TestNetworkCountCheck(tests.TestCase):
         goodurl = '/%s/servers'
         resp = result.__call__.request(goodurl % self.tenant_id, method='POST',
                                        body=body)
-        self.assertEqual(self.app, resp)
+        self.assertTrue(isinstance(resp, webob.exc.HTTPForbidden))
 
     def test_boot_suports_no_networks(self):
         m_ctx = self.create_patch(self.ctx_path)

--- a/wafflehaus/nova/networking/network_count_check.py
+++ b/wafflehaus/nova/networking/network_count_check.py
@@ -128,7 +128,7 @@ class BootNetworkCountCheck(object):
         networks = self._get_networks(_get_body(req, "server",
                                                 self.xml_deserializer))
         if networks is None:
-            return None
+            return set()
         if not networks:
             return set()
         return set(networks)
@@ -137,8 +137,6 @@ class BootNetworkCountCheck(object):
         """Checks required/banned/count of networks."""
         cfg = self.check_config
         networks = self._get_networks_from_request(req)
-        if networks is None:
-            return ""
 
         msg = check_required_networks(networks, cfg.required_networks)
         if msg:


### PR DESCRIPTION
### Summary
- Adjusted the code to return an empty set when there is no networks field specified in the api request
- Removed the None check in the check_networks function since the function it calls to parse the network no longer returns None and instead returns an empty set
### Testing
- Tested these changes in Rackspace PreProd to validate the requests get rejected properly and still accepts appropriate requests.
