### PR TITLE
Added strict_boot_check config paramater

### DIFF
--- a/tests/test_network_count_check.py
+++ b/tests/test_network_count_check.py
@@ -343,7 +343,57 @@ class TestNetworkCountCheck(tests.TestCase):
         goodurl = '/%s/servers'
         resp = result.__call__.request(goodurl % self.tenant_id, method='POST',
                                        body=body)
+        self.assertEqual(self.app, resp)
+
+    def test_boot_suports_no_network_in_body_with_strict_boot_check_on(self):
+        m_ctx = self.create_patch(self.ctx_path)
+        m_ctx.return_value = self.context
+        conf = {'networks_min': '0', 'networks_max': '2',
+                'required_nets': self.pubuuid, 'enabled': 'true',
+                'strict_boot_check': 'true'}
+
+        result = network_count_check.filter_factory(conf)(self.app)
+        self.assertEqual(0, result.check_config.networks_min)
+
+        body = '{"server": {}}'
+
+        goodurl = '/%s/servers'
+        resp = result.__call__.request(goodurl % self.tenant_id, method='POST',
+                                       body=body)
         self.assertTrue(isinstance(resp, webob.exc.HTTPForbidden))
+
+    def test_boot_suports_no_network_in_body_with_strict_boot_check_off(self):
+        m_ctx = self.create_patch(self.ctx_path)
+        m_ctx.return_value = self.context
+        conf = {'networks_min': '0', 'networks_max': '2',
+                'required_nets': self.pubuuid, 'enabled': 'true',
+                'strict_boot_check': ''}
+
+        result = network_count_check.filter_factory(conf)(self.app)
+        self.assertEqual(0, result.check_config.networks_min)
+
+        body = '{"server": {}}'
+
+        goodurl = '/%s/servers'
+        resp = result.__call__.request(goodurl % self.tenant_id, method='POST',
+                                       body=body)
+        self.assertEqual(self.app, resp)
+
+    def test_boot_suports_no_network_in_body_without_strict_boot_check(self):
+        m_ctx = self.create_patch(self.ctx_path)
+        m_ctx.return_value = self.context
+        conf = {'networks_min': '0', 'networks_max': '2',
+                'required_nets': self.pubuuid, 'enabled': 'true'}
+
+        result = network_count_check.filter_factory(conf)(self.app)
+        self.assertEqual(0, result.check_config.networks_min)
+
+        body = '{"server": {}}'
+
+        goodurl = '/%s/servers'
+        resp = result.__call__.request(goodurl % self.tenant_id, method='POST',
+                                       body=body)
+        self.assertEqual(self.app, resp)
 
     def test_boot_suports_no_networks(self):
         m_ctx = self.create_patch(self.ctx_path)

--- a/wafflehaus/nova/networking/network_count_check.py
+++ b/wafflehaus/nova/networking/network_count_check.py
@@ -95,6 +95,8 @@ class NetworkCountConfig(object):
         self.networks_max = int(local_config.get("networks_max", "1"))
         self.count_optional_nets = bool(local_config.get(
             "count_optional_nets", False))
+        self.strict_boot_check = bool(local_config.get(
+            "strict_boot_check", False))
 
 
 class BootNetworkCountCheck(object):
@@ -128,7 +130,7 @@ class BootNetworkCountCheck(object):
         networks = self._get_networks(_get_body(req, "server",
                                                 self.xml_deserializer))
         if networks is None:
-            return set()
+            return None
         if not networks:
             return set()
         return set(networks)
@@ -137,6 +139,12 @@ class BootNetworkCountCheck(object):
         """Checks required/banned/count of networks."""
         cfg = self.check_config
         networks = self._get_networks_from_request(req)
+
+        if cfg.strict_boot_check and networks is None:
+            networks = set()
+
+        if networks is None:
+            return ""
 
         msg = check_required_networks(networks, cfg.required_networks)
         if msg:


### PR DESCRIPTION
### Summary
- Reverted the previous change for the None check on the networks field and made it configurable instead
- Added a scrict_boot_check configuration value to let us specify on boot 
  if we should run checks if the networks field was not passed in to the api request.
### Testing
- Updated the originally modified test to verify it returns an empty string response without the check specified
- Added a new test verifying it would pass back a 403 if strict_boot_check is true with invalid networks
- Added two tests verifying strict_boot_check is false or missing that the result would not be a 403
  even if the networks don't pass the tests
- Ran all tests locally with tox and verified they all passed
