### PR TITLE
Do not assume everything is a network when counting

### DIFF
--- a/tests/test_network_count_check.py
+++ b/tests/test_network_count_check.py
@@ -540,3 +540,18 @@ class TestNetworkCountCheck(tests.TestCase):
                                        body=body, headers=headers)
         self.assertFalse(isinstance(resp, webob.exc.HTTPForbidden))
         self.assertFalse('but missing' in str(resp))
+
+    def test_boot_suports_port(self):
+        m_ctx = self.create_patch(self.ctx_path)
+        m_ctx.return_value = self.context
+        conf = {'networks_min': '0', 'enabled': 'true'}
+
+        result = network_count_check.filter_factory(conf)(self.app)
+        self.assertEqual(0, result.check_config.networks_min)
+
+        body = '{"server": {"networks":[{"port": "fake-port"}]}}'
+
+        goodurl = '/%s/servers'
+        resp = result.__call__.request(goodurl % self.tenant_id, method='POST',
+                                       body=body)
+        self.assertEqual(self.app, resp)

--- a/wafflehaus/nova/networking/network_count_check.py
+++ b/wafflehaus/nova/networking/network_count_check.py
@@ -119,7 +119,7 @@ class BootNetworkCountCheck(object):
         networks = body.get("networks")
         if networks is None:
             return None
-        return [n["uuid"] for n in networks]
+        return [n["uuid"] for n in networks if "uuid" in n]
 
     def _get_networks_from_request(self, req):
         """Returns networks given in server boot request."""


### PR DESCRIPTION
The network count check assumed that everything passed to it was a
network. This is not true so we should exclude things that don't look
like networks.