### PR TITLE
Request instance as object instead of dict

### DIFF
--- a/wafflehaus/nova/nova_base.py
+++ b/wafflehaus/nova/nova_base.py
@@ -35,5 +35,5 @@ class WafflehausNova(WafflehausBase):
     def _get_instance(self, context, server_id):
         """Mock target for testing."""
         compute_api = self.compute.API()
-        instance = compute_api.get(context, server_id)
+        instance = compute_api.get(context, server_id, want_objects=True)
         return instance


### PR DESCRIPTION
Nova has changed to expect instances as objects rather than dicts
This change fixes several errors with Nova when passing in an instance
as a dict.